### PR TITLE
make gap computation robust against missing upper/lower bounds

### DIFF
--- a/miplearn/benchmark.py
+++ b/miplearn/benchmark.py
@@ -74,6 +74,14 @@ class BenchmarkRunner:
         for (solver_name, solver) in self.solvers.items():
             solver.fit(training_instances)
 
+    def computeGap(self, ub, lb):
+        # solver did not find a solution and/or bound, use maximum gap possible
+        if lb is None or ub is None or lb * ub < 0:
+            return 1.0
+        else:
+            # divide by max(abs(ub),abs(lb)) to ensure gap <= 1
+            return (ub - lb) / max(abs(ub), abs(lb))
+
     def _push_result(self, result, solver, solver_name, instance):
         if self.results is None:
             self.results = pd.DataFrame(
@@ -93,7 +101,8 @@ class BenchmarkRunner:
             )
         lb = result["Lower bound"]
         ub = result["Upper bound"]
-        gap = (ub - lb) / lb
+        gap = self.computeGap(ub, lb)
+
         if "Predicted LB" not in result:
             result["Predicted LB"] = float("nan")
             result["Predicted UB"] = float("nan")


### PR DESCRIPTION
This PR makes the gap computation more robust by checking if upper and/or lower bound are None. This can happen if the solver does not find a solution within the time limit.

I slightly changed the definition of gap. Previously, the denominator was `lb`, now it is `max(abs(lb), abs(ub))`, which is simply `ub` if both values are nonnegative. This new gap is bounded from above by 1, which is now returned if upper and/or lower bound are missing.

It may be that these checks need to be extended to involve 1e+40, 1e+20, and Inf (does Python have Inf?). However, in those cases, the gap computation should yield something very close to 1.

Let me know what you think.